### PR TITLE
move babel-runtime to main dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
   },
   "devDependencies": {
     "babel": "^5.6.4",
-    "babel-runtime": "^5.6.4",
     "chai": "^1.10.0",
     "co": "^4.0.0",
     "ejs": "^1.0.0",
@@ -41,6 +40,7 @@
     "mocha-generators": "^1.0.0"
   },
   "dependencies": {
+    "babel-runtime": "^5.6.4",
     "class-extend": "^0.1.1",
     "co-views": "^0.2.0",
     "nodemailer": "^1.3.0",


### PR DESCRIPTION
This is just a minor fix after my update from yesterday. Looks like I missed making the Babel-runtime package a normal dependency. It's being used in the build/mailmain.js file. I must've not noticed it until I install 0.3.3 today.
